### PR TITLE
feat: 視聴履歴機能のフロントエンド実装

### DIFF
--- a/src/app/dashboard/history/page.tsx
+++ b/src/app/dashboard/history/page.tsx
@@ -1,0 +1,338 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { motion } from "framer-motion";
+import { listenHistoryApi } from "../../../lib/api";
+import { useAudioPlayer } from "../../../contexts/AudioPlayerContext";
+import { ListenHistory } from "../../../types/listenHistory";
+import {
+  PlayIcon,
+  PauseIcon,
+  ClockIcon,
+  UserIcon,
+  TrashIcon,
+  HistoryIcon,
+  ChevronRightIcon,
+} from "@heroicons/react/24/outline";
+import { useRouter } from "next/navigation";
+
+export default function HistoryPage() {
+  const router = useRouter();
+  const { state: audioPlayerState, playAudio, pauseAudio } = useAudioPlayer();
+  const [history, setHistory] = useState<ListenHistory[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  const fetchHistory = useCallback(async (page = 1) => {
+    try {
+      setLoading(true);
+      const response = await listenHistoryApi.getAll({ 
+        page, 
+        limit: 10 
+      });
+      setHistory(response.data);
+      setTotalPages(response.totalPages);
+      setCurrentPage(page);
+      setError(null);
+    } catch (err) {
+      setError("視聴履歴の取得に失敗しました");
+      console.error("Error fetching history:", err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchHistory();
+  }, [fetchHistory]);
+
+  const formatTime = (seconds: number) => {
+    const minutes = Math.floor(seconds / 60);
+    const remainingSeconds = Math.floor(seconds % 60);
+    return `${minutes}:${remainingSeconds.toString().padStart(2, "0")}`;
+  };
+
+  const formatDuration = (seconds?: number) => {
+    if (!seconds) return "不明";
+    return formatTime(seconds);
+  };
+
+  const calculateProgress = (currentTime: number, duration?: number) => {
+    if (!duration) return 0;
+    return Math.min((currentTime / duration) * 100, 100);
+  };
+
+  const togglePlay = useCallback(
+    async (historyItem: ListenHistory) => {
+      const content = historyItem.audioContent;
+      const isCurrentlyPlaying =
+        audioPlayerState.currentAudio?.id === content.id.toString() &&
+        audioPlayerState.isPlaying;
+
+      if (isCurrentlyPlaying) {
+        await pauseAudio();
+      } else {
+        const audioUrl = content.audioUrl;
+        if (!audioUrl || !audioUrl.startsWith("http")) {
+          console.error("有効なaudioUrlが提供されていません:", content);
+          return;
+        }
+
+        const audioContent = {
+          id: content.id.toString(),
+          title: content.title,
+          description: content.description,
+          audioUrl: audioUrl,
+          duration: content.duration,
+          startTime: historyItem.currentTime, // 前回の再生位置から開始
+        };
+
+        await playAudio(audioContent);
+      }
+    },
+    [
+      audioPlayerState.currentAudio,
+      audioPlayerState.isPlaying,
+      pauseAudio,
+      playAudio,
+    ],
+  );
+
+  const handleDelete = async (historyItem: ListenHistory) => {
+    if (window.confirm("この視聴履歴を削除しますか？")) {
+      try {
+        await listenHistoryApi.delete(historyItem.id);
+        setHistory(prev => prev.filter(h => h.id !== historyItem.id));
+        setSuccessMessage(`「${historyItem.audioContent.title}」の視聴履歴を削除しました`);
+        setTimeout(() => setSuccessMessage(null), 3000);
+      } catch (err) {
+        setError("視聴履歴の削除に失敗しました");
+        console.error("Error deleting history:", err);
+      }
+    }
+  };
+
+  const HistoryCard = ({ historyItem }: { historyItem: ListenHistory }) => {
+    const progress = calculateProgress(historyItem.currentTime, historyItem.duration);
+    
+    return (
+      <div className="bg-white dark:bg-gray-800 rounded-xl p-5 hover:shadow-md transition-all duration-200 border border-gray-200 dark:border-gray-700">
+        {/* プログレスバー */}
+        <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-1 mb-4">
+          <div
+            className="bg-blue-500 h-1 rounded-full transition-all duration-300"
+            style={{ width: `${progress}%` }}
+          />
+        </div>
+
+        <div className="flex justify-between items-start mb-4">
+          <span className="px-3 py-1 bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 text-xs font-medium rounded-full">
+            {historyItem.audioContent.category.name}
+          </span>
+          <div className="flex items-center space-x-2">
+            <span className="text-gray-500 dark:text-gray-400 text-sm flex items-center">
+              <ClockIcon className="h-4 w-4 mr-1" />
+              {formatTime(historyItem.currentTime)} / {formatDuration(historyItem.duration)}
+            </span>
+            <button
+              onClick={() => handleDelete(historyItem)}
+              className="p-1 text-gray-400 hover:text-red-500 transition-colors"
+              title="履歴から削除"
+            >
+              <TrashIcon className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+
+        <h4 className="text-gray-900 dark:text-white text-lg font-semibold mb-2 line-clamp-2">
+          {historyItem.audioContent.title}
+        </h4>
+        <p className="text-gray-600 dark:text-gray-400 text-sm mb-4 line-clamp-2">
+          {historyItem.audioContent.description}
+        </p>
+
+        <div className="flex items-center justify-between mb-4">
+          <div className="flex items-center space-x-2">
+            <UserIcon className="h-4 w-4 text-gray-400" />
+            <span className="text-gray-600 dark:text-gray-400 text-sm">
+              {historyItem.audioContent.author.name}
+            </span>
+          </div>
+          <div className="flex items-center space-x-4">
+            {historyItem.completed && (
+              <span className="px-2 py-1 bg-green-100 dark:bg-green-900/30 text-green-600 dark:text-green-400 text-xs font-medium rounded-full">
+                完了
+              </span>
+            )}
+            <span className="text-gray-500 dark:text-gray-400 text-xs">
+              {new Date(historyItem.updatedAt).toLocaleDateString("ja-JP")}
+            </span>
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between">
+          <button
+            onClick={() => togglePlay(historyItem)}
+            disabled={audioPlayerState.isLoading}
+            className="flex items-center space-x-2 px-4 py-2 bg-blue-500 hover:bg-blue-600 disabled:bg-gray-400 text-white rounded-lg transition-colors text-sm font-medium"
+          >
+            {audioPlayerState.isLoading &&
+            audioPlayerState.currentAudio?.id === historyItem.audioContent.id.toString() ? (
+              <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white"></div>
+            ) : audioPlayerState.currentAudio?.id === historyItem.audioContent.id.toString() &&
+              audioPlayerState.isPlaying ? (
+              <PauseIcon className="h-4 w-4" />
+            ) : (
+              <PlayIcon className="h-4 w-4" />
+            )}
+            <span>
+              {audioPlayerState.currentAudio?.id === historyItem.audioContent.id.toString() &&
+              audioPlayerState.isPlaying
+                ? "一時停止"
+                : "続きから再生"}
+            </span>
+          </button>
+
+          <span className="text-sm text-gray-500 dark:text-gray-400">
+            進捗: {Math.round(progress)}%
+          </span>
+        </div>
+      </div>
+    );
+  };
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center py-12">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500"></div>
+        <span className="ml-3 text-gray-600 dark:text-gray-400">
+          読み込み中...
+        </span>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex justify-center items-center py-12">
+        <div className="text-red-500 dark:text-red-400">{error}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-8">
+      {/* 成功メッセージ */}
+      {successMessage && (
+        <motion.div
+          initial={{ opacity: 0, y: -20 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: -20 }}
+          className="fixed top-4 right-4 bg-green-500 text-white px-6 py-3 rounded-lg shadow-lg z-50 flex items-center space-x-2"
+        >
+          <div className="w-5 h-5 rounded-full bg-white flex items-center justify-center">
+            <svg className="w-3 h-3 text-green-500" fill="currentColor" viewBox="0 0 20 20">
+              <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+            </svg>
+          </div>
+          <span className="font-medium">{successMessage}</span>
+        </motion.div>
+      )}
+
+      {/* ヘッダー */}
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-sm border border-gray-200 dark:border-gray-700"
+      >
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-2 flex items-center">
+              <HistoryIcon className="h-8 w-8 mr-3 text-blue-500" />
+              視聴履歴
+            </h2>
+            <p className="text-gray-600 dark:text-gray-400">
+              最近視聴したコンテンツを確認し、続きから再生できます
+            </p>
+          </div>
+          <div className="text-right">
+            <p className="text-sm text-gray-500 dark:text-gray-400">合計</p>
+            <p className="text-2xl font-bold text-gray-900 dark:text-white">
+              {history.length}
+            </p>
+            <p className="text-sm text-gray-500 dark:text-gray-400">コンテンツ</p>
+          </div>
+        </div>
+      </motion.div>
+
+      {/* 視聴履歴一覧 */}
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.2 }}
+        className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-sm border border-gray-200 dark:border-gray-700"
+      >
+        <div className="flex items-center justify-between mb-6">
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+            視聴履歴一覧
+          </h3>
+          <span className="text-gray-500 dark:text-gray-400 text-sm">
+            {history.length}件
+          </span>
+        </div>
+
+        {history.length === 0 ? (
+          <div className="text-center py-12">
+            <HistoryIcon className="h-12 w-12 text-gray-400 mx-auto mb-4" />
+            <h4 className="text-lg font-medium text-gray-900 dark:text-white mb-2">
+              視聴履歴がありません
+            </h4>
+            <p className="text-gray-600 dark:text-gray-400 mb-6">
+              コンテンツを視聴すると、ここに履歴が表示されます
+            </p>
+            <button
+              onClick={() => router.push("/dashboard/discover")}
+              className="inline-flex items-center space-x-2 px-6 py-3 bg-blue-500 hover:bg-blue-600 text-white rounded-lg transition-colors font-medium"
+            >
+              <span>コンテンツを探す</span>
+              <ChevronRightIcon className="h-5 w-5" />
+            </button>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {history.map((historyItem) => (
+              <HistoryCard key={historyItem.id} historyItem={historyItem} />
+            ))}
+          </div>
+        )}
+      </motion.div>
+
+      {/* ページネーション */}
+      {totalPages > 1 && (
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.4 }}
+          className="flex justify-center space-x-2"
+        >
+          {Array.from({ length: totalPages }, (_, i) => i + 1).map((page) => (
+            <button
+              key={page}
+              onClick={() => fetchHistory(page)}
+              className={`px-4 py-2 rounded-lg font-medium transition-colors ${
+                currentPage === page
+                  ? "bg-blue-500 text-white"
+                  : "bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 border border-gray-200 dark:border-gray-700"
+              }`}
+            >
+              {page}
+            </button>
+          ))}
+        </motion.div>
+      )}
+    </div>
+  );
+}

--- a/src/app/dashboard/history/page.tsx
+++ b/src/app/dashboard/history/page.tsx
@@ -11,7 +11,7 @@ import {
   ClockIcon,
   UserIcon,
   TrashIcon,
-  HistoryIcon,
+  BookOpenIcon,
   ChevronRightIcon,
 } from "@heroicons/react/24/outline";
 import { useRouter } from "next/navigation";
@@ -251,7 +251,7 @@ export default function HistoryPage() {
         <div className="flex items-center justify-between">
           <div>
             <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-2 flex items-center">
-              <HistoryIcon className="h-8 w-8 mr-3 text-blue-500" />
+              <BookOpenIcon className="h-8 w-8 mr-3 text-blue-500" />
               視聴履歴
             </h2>
             <p className="text-gray-600 dark:text-gray-400">
@@ -286,7 +286,7 @@ export default function HistoryPage() {
 
         {history.length === 0 ? (
           <div className="text-center py-12">
-            <HistoryIcon className="h-12 w-12 text-gray-400 mx-auto mb-4" />
+            <BookOpenIcon className="h-12 w-12 text-gray-400 mx-auto mb-4" />
             <h4 className="text-lg font-medium text-gray-900 dark:text-white mb-2">
               視聴履歴がありません
             </h4>

--- a/src/app/dashboard/search/page.tsx
+++ b/src/app/dashboard/search/page.tsx
@@ -1,0 +1,515 @@
+"use client";
+
+import { useState, useEffect, Suspense } from "react";
+import { useSearchParams } from "next/navigation";
+import { motion } from "framer-motion";
+import { audioContentApi } from "../../../lib/api";
+import SearchBar from "../../../components/SearchBar";
+import {
+  MagnifyingGlassIcon,
+  FunnelIcon,
+  PlayIcon,
+  HeartIcon,
+  ClockIcon,
+  XMarkIcon
+} from "@heroicons/react/24/outline";
+import { HeartIcon as HeartSolidIcon } from "@heroicons/react/24/solid";
+
+interface AudioContent {
+  id: string;
+  title: string;
+  description: string;
+  category: string;
+  duration: number;
+  audioUrl: string;
+  thumbnailUrl?: string;
+  isLiked?: boolean;
+  createdAt: string;
+  author?: {
+    name: string;
+  };
+}
+
+interface SearchFilters {
+  category: string;
+  duration: string;
+  sortBy: string;
+}
+
+const categories = [
+  { value: "", label: "すべてのカテゴリ" },
+  { value: "education", label: "教育" },
+  { value: "entertainment", label: "エンターテイメント" },
+  { value: "news", label: "ニュース" },
+  { value: "music", label: "音楽" },
+  { value: "podcast", label: "ポッドキャスト" },
+  { value: "language", label: "語学" },
+  { value: "business", label: "ビジネス" },
+  { value: "health", label: "健康" },
+  { value: "technology", label: "テクノロジー" },
+  { value: "lifestyle", label: "ライフスタイル" }
+];
+
+const durationFilters = [
+  { value: "", label: "すべての長さ" },
+  { value: "short", label: "短時間 (5分未満)" },
+  { value: "medium", label: "中時間 (5-20分)" },
+  { value: "long", label: "長時間 (20分以上)" }
+];
+
+const sortOptions = [
+  { value: "relevance", label: "関連度順" },
+  { value: "newest", label: "新着順" },
+  { value: "oldest", label: "古い順" },
+  { value: "duration_asc", label: "短い順" },
+  { value: "duration_desc", label: "長い順" },
+  { value: "title", label: "タイトル順" }
+];
+
+function SearchPageContent() {
+  const searchParams = useSearchParams();
+  const [searchResults, setSearchResults] = useState<AudioContent[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [showFilters, setShowFilters] = useState(false);
+  const [totalResults, setTotalResults] = useState(0);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [query, setQuery] = useState("");
+
+  const [filters, setFilters] = useState<SearchFilters>({
+    category: "",
+    duration: "",
+    sortBy: "relevance"
+  });
+
+  // URLパラメータから検索クエリを取得
+  useEffect(() => {
+    const searchQuery = searchParams.get('q');
+    if (searchQuery) {
+      setQuery(searchQuery);
+      performSearch(searchQuery, filters, 1);
+    }
+  }, [searchParams]);
+
+  const performSearch = async (searchQuery: string, searchFilters: SearchFilters, page: number = 1) => {
+    if (!searchQuery.trim()) return;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const params: any = {
+        search: searchQuery,
+        page,
+        limit: 20
+      };
+
+      if (searchFilters.category) {
+        params.category = searchFilters.category;
+      }
+
+      // 期間フィルタを適用
+      if (searchFilters.duration) {
+        switch (searchFilters.duration) {
+          case 'short':
+            params.maxDuration = 300; // 5分
+            break;
+          case 'medium':
+            params.minDuration = 300;
+            params.maxDuration = 1200; // 20分
+            break;
+          case 'long':
+            params.minDuration = 1200;
+            break;
+        }
+      }
+
+      // ソート順を適用
+      if (searchFilters.sortBy !== 'relevance') {
+        params.sortBy = searchFilters.sortBy;
+      }
+
+      const response = await audioContentApi.getAll(params);
+      
+      if (page === 1) {
+        setSearchResults(response.data || []);
+      } else {
+        setSearchResults(prev => [...prev, ...(response.data || [])]);
+      }
+      
+      setTotalResults(response.total || 0);
+      setCurrentPage(page);
+    } catch (err) {
+      setError('検索中にエラーが発生しました。もう一度お試しください。');
+      console.error('Search error:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleFilterChange = (newFilters: Partial<SearchFilters>) => {
+    const updatedFilters = { ...filters, ...newFilters };
+    setFilters(updatedFilters);
+    if (query) {
+      performSearch(query, updatedFilters, 1);
+    }
+  };
+
+  const handleLoadMore = () => {
+    if (query && !loading) {
+      performSearch(query, filters, currentPage + 1);
+    }
+  };
+
+  const formatDuration = (seconds: number): string => {
+    const minutes = Math.floor(seconds / 60);
+    const remainingSeconds = seconds % 60;
+    return `${minutes}:${remainingSeconds.toString().padStart(2, '0')}`;
+  };
+
+  const formatDate = (dateString: string): string => {
+    const date = new Date(dateString);
+    return date.toLocaleDateString('ja-JP', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric'
+    });
+  };
+
+  const clearFilters = () => {
+    const defaultFilters = {
+      category: "",
+      duration: "",
+      sortBy: "relevance"
+    };
+    setFilters(defaultFilters);
+    if (query) {
+      performSearch(query, defaultFilters, 1);
+    }
+  };
+
+  const hasActiveFilters = filters.category || filters.duration || filters.sortBy !== "relevance";
+
+  return (
+    <div className="space-y-6">
+      {/* 検索バー */}
+      <div className="bg-white dark:bg-gray-800 rounded-lg p-6 shadow-sm">
+        <SearchBar
+          initialQuery={query}
+          placeholder="音声コンテンツを検索..."
+          showHistory={true}
+          onSearch={(searchQuery) => {
+            setQuery(searchQuery);
+            performSearch(searchQuery, filters, 1);
+          }}
+          className="max-w-2xl mx-auto"
+        />
+      </div>
+
+      {/* 検索結果とフィルター */}
+      {query && (
+        <>
+          {/* 検索結果ヘッダー */}
+          <div className="flex items-center justify-between">
+            <div className="flex items-center space-x-4">
+              <div>
+                <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
+                  「{query}」の検索結果
+                </h2>
+                {totalResults > 0 && (
+                  <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+                    約 {totalResults.toLocaleString()} 件見つかりました
+                  </p>
+                )}
+              </div>
+            </div>
+
+            {/* フィルターボタン */}
+            <div className="flex items-center space-x-2">
+              {hasActiveFilters && (
+                <button
+                  onClick={clearFilters}
+                  className="flex items-center space-x-1 px-3 py-2 text-sm text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-lg transition-colors"
+                >
+                  <XMarkIcon className="h-4 w-4" />
+                  <span>フィルターをクリア</span>
+                </button>
+              )}
+              
+              <button
+                onClick={() => setShowFilters(!showFilters)}
+                className={`flex items-center space-x-2 px-4 py-2 rounded-lg border transition-colors ${
+                  showFilters
+                    ? 'bg-blue-50 dark:bg-blue-900/20 border-blue-200 dark:border-blue-700 text-blue-700 dark:text-blue-300'
+                    : 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700'
+                }`}
+              >
+                <FunnelIcon className="h-4 w-4" />
+                <span>フィルター</span>
+                {hasActiveFilters && (
+                  <span className="ml-1 px-2 py-0.5 bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200 text-xs rounded-full">
+                    {[filters.category, filters.duration, filters.sortBy !== "relevance" ? filters.sortBy : ""].filter(Boolean).length}
+                  </span>
+                )}
+              </button>
+            </div>
+          </div>
+
+          {/* フィルターパネル */}
+          {showFilters && (
+            <motion.div
+              initial={{ opacity: 0, height: 0 }}
+              animate={{ opacity: 1, height: "auto" }}
+              exit={{ opacity: 0, height: 0 }}
+              className="bg-white dark:bg-gray-800 rounded-lg p-6 shadow-sm"
+            >
+              <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+                検索フィルター
+              </h3>
+              
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+                {/* カテゴリ */}
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                    カテゴリ
+                  </label>
+                  <select
+                    value={filters.category}
+                    onChange={(e) => handleFilterChange({ category: e.target.value })}
+                    className="w-full px-3 py-2 bg-gray-50 dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-gray-900 dark:text-white"
+                  >
+                    {categories.map((cat) => (
+                      <option key={cat.value} value={cat.value}>
+                        {cat.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                {/* 期間 */}
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                    長さ
+                  </label>
+                  <select
+                    value={filters.duration}
+                    onChange={(e) => handleFilterChange({ duration: e.target.value })}
+                    className="w-full px-3 py-2 bg-gray-50 dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-gray-900 dark:text-white"
+                  >
+                    {durationFilters.map((dur) => (
+                      <option key={dur.value} value={dur.value}>
+                        {dur.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                {/* ソート */}
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                    並び順
+                  </label>
+                  <select
+                    value={filters.sortBy}
+                    onChange={(e) => handleFilterChange({ sortBy: e.target.value })}
+                    className="w-full px-3 py-2 bg-gray-50 dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-gray-900 dark:text-white"
+                  >
+                    {sortOptions.map((sort) => (
+                      <option key={sort.value} value={sort.value}>
+                        {sort.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+            </motion.div>
+          )}
+
+          {/* 検索結果 */}
+          {loading && searchResults.length === 0 ? (
+            <div className="flex items-center justify-center py-12">
+              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500"></div>
+              <span className="ml-3 text-gray-600 dark:text-gray-400">検索中...</span>
+            </div>
+          ) : error ? (
+            <div className="text-center py-12">
+              <MagnifyingGlassIcon className="h-12 w-12 text-gray-400 mx-auto mb-4" />
+              <p className="text-gray-600 dark:text-gray-400 mb-4">{error}</p>
+              <button
+                onClick={() => performSearch(query, filters, 1)}
+                className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+              >
+                再試行
+              </button>
+            </div>
+          ) : searchResults.length === 0 ? (
+            <div className="text-center py-12">
+              <MagnifyingGlassIcon className="h-12 w-12 text-gray-400 mx-auto mb-4" />
+              <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-2">
+                検索結果が見つかりませんでした
+              </h3>
+              <p className="text-gray-600 dark:text-gray-400 mb-4">
+                別のキーワードで検索してみてください
+              </p>
+              {hasActiveFilters && (
+                <button
+                  onClick={clearFilters}
+                  className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+                >
+                  フィルターをクリアして再検索
+                </button>
+              )}
+            </div>
+          ) : (
+            <>
+              {/* 検索結果一覧 */}
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                {searchResults.map((content, index) => (
+                  <motion.div
+                    key={content.id}
+                    initial={{ opacity: 0, y: 20 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ duration: 0.3, delay: index * 0.05 }}
+                    className="bg-white dark:bg-gray-800 rounded-lg shadow-sm hover:shadow-md transition-shadow overflow-hidden"
+                  >
+                    {/* サムネイル */}
+                    <div className="relative aspect-video bg-gray-200 dark:bg-gray-700">
+                      {content.thumbnailUrl ? (
+                        <img
+                          src={content.thumbnailUrl}
+                          alt={content.title}
+                          className="w-full h-full object-cover"
+                        />
+                      ) : (
+                        <div className="flex items-center justify-center h-full">
+                          <PlayIcon className="h-12 w-12 text-gray-400" />
+                        </div>
+                      )}
+                      
+                      {/* 再生時間 */}
+                      <div className="absolute bottom-2 right-2 bg-black/70 text-white text-xs px-2 py-1 rounded">
+                        {formatDuration(content.duration)}
+                      </div>
+                    </div>
+
+                    {/* コンテンツ情報 */}
+                    <div className="p-4">
+                      <div className="flex items-start justify-between mb-2">
+                        <h3 className="font-semibold text-gray-900 dark:text-white text-sm line-clamp-2 flex-1">
+                          {content.title}
+                        </h3>
+                        <button className="ml-2 p-1 text-gray-400 hover:text-red-500 transition-colors">
+                          {content.isLiked ? (
+                            <HeartSolidIcon className="h-5 w-5 text-red-500" />
+                          ) : (
+                            <HeartIcon className="h-5 w-5" />
+                          )}
+                        </button>
+                      </div>
+
+                      <p className="text-gray-600 dark:text-gray-400 text-sm line-clamp-2 mb-3">
+                        {content.description}
+                      </p>
+
+                      <div className="flex items-center justify-between text-xs text-gray-500 dark:text-gray-400">
+                        <div className="flex items-center space-x-2">
+                          <span className="bg-gray-100 dark:bg-gray-700 px-2 py-1 rounded">
+                            {categories.find(cat => cat.value === content.category)?.label || content.category}
+                          </span>
+                        </div>
+                        
+                        <div className="flex items-center space-x-1">
+                          <ClockIcon className="h-3 w-3" />
+                          <span>{formatDate(content.createdAt)}</span>
+                        </div>
+                      </div>
+
+                      {content.author && (
+                        <div className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+                          by {content.author.name}
+                        </div>
+                      )}
+
+                      {/* 再生ボタン */}
+                      <button className="w-full mt-3 flex items-center justify-center space-x-2 bg-blue-600 hover:bg-blue-700 text-white py-2 px-4 rounded-lg transition-colors">
+                        <PlayIcon className="h-4 w-4" />
+                        <span>再生</span>
+                      </button>
+                    </div>
+                  </motion.div>
+                ))}
+              </div>
+
+              {/* もっと読み込むボタン */}
+              {searchResults.length < totalResults && (
+                <div className="text-center pt-6">
+                  <button
+                    onClick={handleLoadMore}
+                    disabled={loading}
+                    className="px-6 py-3 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400 text-white rounded-lg transition-colors"
+                  >
+                    {loading ? (
+                      <div className="flex items-center space-x-2">
+                        <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white"></div>
+                        <span>読み込み中...</span>
+                      </div>
+                    ) : (
+                      'さらに表示'
+                    )}
+                  </button>
+                </div>
+              )}
+            </>
+          )}
+        </>
+      )}
+
+      {/* 初期状態（検索クエリがない場合） */}
+      {!query && (
+        <div className="text-center py-12">
+          <MagnifyingGlassIcon className="h-16 w-16 text-gray-300 dark:text-gray-600 mx-auto mb-4" />
+          <h2 className="text-2xl font-semibold text-gray-900 dark:text-white mb-2">
+            音声コンテンツを検索
+          </h2>
+          <p className="text-gray-600 dark:text-gray-400 mb-6">
+            上の検索バーにキーワードを入力して、お探しのコンテンツを見つけましょう
+          </p>
+          
+          {/* 人気のカテゴリ */}
+          <div className="max-w-md mx-auto">
+            <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">
+              人気のカテゴリ
+            </h3>
+            <div className="flex flex-wrap gap-2 justify-center">
+              {categories.slice(1, 7).map((category) => (
+                <button
+                  key={category.value}
+                  onClick={() => {
+                    setQuery(category.label);
+                    performSearch(category.label, filters, 1);
+                  }}
+                  className="px-3 py-2 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 text-sm rounded-lg transition-colors"
+                >
+                  {category.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function SearchPage() {
+  return (
+    <Suspense fallback={
+      <div className="flex items-center justify-center py-12">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500"></div>
+        <span className="ml-3 text-gray-600 dark:text-gray-400">読み込み中...</span>
+      </div>
+    }>
+      <SearchPageContent />
+    </Suspense>
+  );
+}

--- a/src/app/dashboard/search/page.tsx
+++ b/src/app/dashboard/search/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, Suspense } from "react";
 import { useSearchParams } from "next/navigation";
 import { motion } from "framer-motion";
+import Image from "next/image";
 import { audioContentApi } from "../../../lib/api";
 import SearchBar from "../../../components/SearchBar";
 import {
@@ -89,7 +90,7 @@ function SearchPageContent() {
       setQuery(searchQuery);
       performSearch(searchQuery, filters, 1);
     }
-  }, [searchParams]);
+  }, [searchParams, filters]);
 
   const performSearch = async (searchQuery: string, searchFilters: SearchFilters, page: number = 1) => {
     if (!searchQuery.trim()) return;
@@ -98,7 +99,7 @@ function SearchPageContent() {
     setError(null);
 
     try {
-      const params: any = {
+      const params: Record<string, string | number> = {
         search: searchQuery,
         page,
         limit: 20
@@ -375,9 +376,11 @@ function SearchPageContent() {
                     {/* サムネイル */}
                     <div className="relative aspect-video bg-gray-200 dark:bg-gray-700">
                       {content.thumbnailUrl ? (
-                        <img
+                        <Image
                           src={content.thumbnailUrl}
                           alt={content.title}
+                          width={400}
+                          height={225}
                           className="w-full h-full object-cover"
                         />
                       ) : (

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -17,7 +17,7 @@ export default function LoginForm() {
     setClientError(null);
     
     if (!email || !password) {
-      setClientError("メールアドレスとパスワードを入力してくださaa");
+      setClientError("メールアドレスとパスワードを入力してください");
       return;
     }
     

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -55,7 +55,7 @@ export default function SearchBar({
     if (searchQuery && searchQuery !== query) {
       setQuery(searchQuery);
     }
-  }, [searchParams]);
+  }, [searchParams, query]);
 
   // 外部クリックで候補を非表示
   useEffect(() => {

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { motion, AnimatePresence } from "framer-motion";
+import { MagnifyingGlassIcon, XMarkIcon, ClockIcon } from "@heroicons/react/24/outline";
+
+interface SearchBarProps {
+  initialQuery?: string;
+  className?: string;
+  placeholder?: string;
+  showHistory?: boolean;
+  onSearch?: (query: string) => void;
+}
+
+interface SearchHistoryItem {
+  query: string;
+  timestamp: number;
+}
+
+export default function SearchBar({ 
+  initialQuery = "", 
+  className = "", 
+  placeholder = "音声コンテンツを検索...",
+  showHistory = true,
+  onSearch
+}: SearchBarProps) {
+  const [query, setQuery] = useState(initialQuery);
+  const [isFocused, setIsFocused] = useState(false);
+  const [searchHistory, setSearchHistory] = useState<SearchHistoryItem[]>([]);
+  const [showSuggestions, setShowSuggestions] = useState(false);
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  // 検索履歴をローカルストレージから読み込み
+  useEffect(() => {
+    if (showHistory && typeof window !== 'undefined') {
+      const savedHistory = localStorage.getItem('searchHistory');
+      if (savedHistory) {
+        try {
+          const history = JSON.parse(savedHistory);
+          setSearchHistory(history.slice(0, 5)); // 最大5件表示
+        } catch (error) {
+          console.error('検索履歴の読み込みに失敗しました:', error);
+        }
+      }
+    }
+  }, [showHistory]);
+
+  // 検索パラメータから初期値を設定
+  useEffect(() => {
+    const searchQuery = searchParams.get('q');
+    if (searchQuery && searchQuery !== query) {
+      setQuery(searchQuery);
+    }
+  }, [searchParams]);
+
+  // 外部クリックで候補を非表示
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setShowSuggestions(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const saveToHistory = (searchQuery: string) => {
+    if (!showHistory || !searchQuery.trim()) return;
+
+    const newItem: SearchHistoryItem = {
+      query: searchQuery.trim(),
+      timestamp: Date.now()
+    };
+
+    const updatedHistory = [
+      newItem,
+      ...searchHistory.filter(item => item.query !== newItem.query)
+    ].slice(0, 10); // 最大10件保存
+
+    setSearchHistory(updatedHistory);
+    
+    try {
+      localStorage.setItem('searchHistory', JSON.stringify(updatedHistory));
+    } catch (error) {
+      console.error('検索履歴の保存に失敗しました:', error);
+    }
+  };
+
+  const handleSearch = (searchQuery: string = query) => {
+    const trimmedQuery = searchQuery.trim();
+    if (!trimmedQuery) return;
+
+    saveToHistory(trimmedQuery);
+    setShowSuggestions(false);
+
+    if (onSearch) {
+      onSearch(trimmedQuery);
+    } else {
+      // デフォルトの検索ページに遷移
+      router.push(`/dashboard/search?q=${encodeURIComponent(trimmedQuery)}`);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleSearch();
+    } else if (e.key === 'Escape') {
+      setShowSuggestions(false);
+      inputRef.current?.blur();
+    }
+  };
+
+  const handleFocus = () => {
+    setIsFocused(true);
+    if (showHistory && searchHistory.length > 0) {
+      setShowSuggestions(true);
+    }
+  };
+
+  const handleBlur = () => {
+    setIsFocused(false);
+    // 少し遅延させて候補選択を可能にする
+    setTimeout(() => setShowSuggestions(false), 200);
+  };
+
+  const clearQuery = () => {
+    setQuery("");
+    inputRef.current?.focus();
+  };
+
+  const clearHistory = () => {
+    setSearchHistory([]);
+    localStorage.removeItem('searchHistory');
+    setShowSuggestions(false);
+  };
+
+  const filteredHistory = searchHistory.filter(item =>
+    item.query.toLowerCase().includes(query.toLowerCase())
+  );
+
+  return (
+    <div className={`relative ${className}`} ref={dropdownRef}>
+      <div className="relative">
+        <MagnifyingGlassIcon className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-gray-400" />
+        <input
+          ref={inputRef}
+          type="text"
+          placeholder={placeholder}
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={handleKeyDown}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+          className={`w-full pl-10 pr-10 py-2.5 sm:py-3 text-sm sm:text-base bg-gray-100 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl focus:ring-2 focus:ring-blue-500 focus:border-transparent text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 transition-all ${
+            isFocused ? 'ring-2 ring-blue-500' : ''
+          }`}
+        />
+        {query && (
+          <button
+            onClick={clearQuery}
+            className="absolute right-3 top-1/2 transform -translate-y-1/2 p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+          >
+            <XMarkIcon className="h-4 w-4" />
+          </button>
+        )}
+      </div>
+
+      {/* 検索候補・履歴ドロップダウン */}
+      <AnimatePresence>
+        {showSuggestions && showHistory && filteredHistory.length > 0 && (
+          <motion.div
+            initial={{ opacity: 0, y: -10 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -10 }}
+            transition={{ duration: 0.2 }}
+            className="absolute top-full left-0 right-0 mt-2 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 py-2 z-50"
+          >
+            <div className="flex items-center justify-between px-4 py-2 border-b border-gray-200 dark:border-gray-700">
+              <span className="text-sm font-medium text-gray-600 dark:text-gray-400">
+                最近の検索
+              </span>
+              <button
+                onClick={clearHistory}
+                className="text-xs text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 transition-colors"
+              >
+                履歴を削除
+              </button>
+            </div>
+            
+            {filteredHistory.map((item, index) => (
+              <button
+                key={index}
+                onClick={() => handleSearch(item.query)}
+                className="w-full flex items-center space-x-3 px-4 py-2 text-left hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+              >
+                <ClockIcon className="h-4 w-4 text-gray-400" />
+                <span className="text-sm text-gray-900 dark:text-white flex-1">
+                  {item.query}
+                </span>
+              </button>
+            ))}
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -17,7 +17,8 @@ import {
   BookOpenIcon,
   PlayIcon,
   DocumentTextIcon,
-  ShieldCheckIcon
+  ShieldCheckIcon,
+  ClockIcon
 } from "@heroicons/react/24/outline";
 
 interface SidebarProps {
@@ -41,6 +42,7 @@ export default function Sidebar({ activeTab, onTabChange, isCollapsed, onToggleC
     { id: 'discover', label: '発見', icon: SpeakerWaveIcon },
     { id: 'library', label: 'ライブラリ', icon: BookOpenIcon },
     { id: 'liked', label: 'お気に入り', icon: HeartIcon },
+    { id: 'history', label: '視聴履歴', icon: ClockIcon },
     { id: 'upload', label: '投稿', icon: MicrophoneIcon },
   ];
 

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, Suspense } from "react";
 import { motion } from "framer-motion";
 import { useAuth } from "../contexts/AuthContext";
 import SearchBar from "./SearchBar";
@@ -37,10 +37,12 @@ export default function TopBar({ title, subtitle, isCollapsed }: TopBarProps) {
         </div>
 
         <div className="flex-1 max-w-md mx-8">
-          <SearchBar 
-            placeholder="音声コンテンツを検索..."
-            showHistory={true}
-          />
+          <Suspense fallback={<div className="h-10 bg-gray-100 dark:bg-gray-700 rounded-lg animate-pulse"></div>}>
+            <SearchBar 
+              placeholder="音声コンテンツを検索..."
+              showHistory={true}
+            />
+          </Suspense>
         </div>
 
         <div className="flex items-center space-x-4">

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -3,9 +3,9 @@
 import { useState } from "react";
 import { motion } from "framer-motion";
 import { useAuth } from "../contexts/AuthContext";
+import SearchBar from "./SearchBar";
 import {
   BellIcon,
-  MagnifyingGlassIcon,
   UserCircleIcon,
   ChevronDownIcon,
   Cog6ToothIcon,
@@ -21,7 +21,6 @@ interface TopBarProps {
 export default function TopBar({ title, subtitle, isCollapsed }: TopBarProps) {
   const { user, logout } = useAuth();
   const [showUserMenu, setShowUserMenu] = useState(false);
-  const [searchQuery, setSearchQuery] = useState("");
 
   return (
     <motion.header
@@ -38,16 +37,10 @@ export default function TopBar({ title, subtitle, isCollapsed }: TopBarProps) {
         </div>
 
         <div className="flex-1 max-w-md mx-8">
-          <div className="relative">
-            <MagnifyingGlassIcon className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-gray-400" />
-            <input
-              type="text"
-              placeholder="音声コンテンツを検索..."
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              className="w-full pl-10 pr-4 py-2.5 bg-gray-100 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl focus:ring-2 focus:ring-blue-500 focus:border-transparent text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 transition-all"
-            />
-          </div>
+          <SearchBar 
+            placeholder="音声コンテンツを検索..."
+            showHistory={true}
+          />
         </div>
 
         <div className="flex items-center space-x-4">

--- a/src/contexts/AudioPlayerContext.tsx
+++ b/src/contexts/AudioPlayerContext.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import React, { createContext, useContext, useReducer, ReactNode } from 'react';
-import { playbackApi } from '../lib/api';
+import React, { createContext, useContext, useReducer, ReactNode, useRef, useEffect } from 'react';
+import { playbackApi, listenHistoryApi } from '../lib/api';
 
 interface AudioContent {
   id: string;
@@ -9,6 +9,7 @@ interface AudioContent {
   description: string;
   audioUrl: string;
   duration?: number;
+  startTime?: number; // 視聴履歴から開始する際の時間
 }
 
 interface PlaybackState {
@@ -97,6 +98,78 @@ interface AudioPlayerProviderProps {
 
 export const AudioPlayerProvider: React.FC<AudioPlayerProviderProps> = ({ children }) => {
   const [state, dispatch] = useReducer(audioPlayerReducer, initialState);
+  const historyRecordInterval = useRef<NodeJS.Timeout | null>(null);
+  const lastRecordedTime = useRef<number>(0);
+
+  // 視聴履歴を記録する関数
+  const recordListenHistory = async (audioContent: AudioContent, currentTime: number, duration?: number, completed = false) => {
+    try {
+      await listenHistoryApi.record({
+        audioContentId: parseInt(audioContent.id),
+        currentTime,
+        duration,
+        completed
+      });
+    } catch (error) {
+      console.error('視聴履歴の記録に失敗:', error);
+    }
+  };
+
+  // 視聴履歴の記録を開始する関数
+  const startHistoryRecording = (audioContent: AudioContent) => {
+    if (historyRecordInterval.current) {
+      clearInterval(historyRecordInterval.current);
+    }
+
+    historyRecordInterval.current = setInterval(() => {
+      if (state.currentAudio && state.isPlaying) {
+        const timeDiff = Math.abs(state.currentTime - lastRecordedTime.current);
+        // 5秒以上進んだら記録する
+        if (timeDiff >= 5) {
+          recordListenHistory(audioContent, state.currentTime, audioContent.duration);
+          lastRecordedTime.current = state.currentTime;
+        }
+      }
+    }, 5000); // 5秒間隔で記録
+  };
+
+  // 視聴履歴の記録を停止する関数
+  const stopHistoryRecording = () => {
+    if (historyRecordInterval.current) {
+      clearInterval(historyRecordInterval.current);
+      historyRecordInterval.current = null;
+    }
+  };
+
+  // コンポーネントのアンマウント時にクリーンアップ
+  useEffect(() => {
+    return () => {
+      stopHistoryRecording();
+    };
+  }, []);
+
+  // 再生状態の変化を監視して履歴記録を制御
+  useEffect(() => {
+    if (state.currentAudio) {
+      if (state.isPlaying) {
+        startHistoryRecording(state.currentAudio);
+      } else {
+        stopHistoryRecording();
+        // 停止時に現在の位置を記録
+        if (state.currentTime > 0) {
+          recordListenHistory(state.currentAudio, state.currentTime, state.currentAudio.duration);
+        }
+      }
+    }
+  }, [state.isPlaying, state.currentAudio]);
+
+  // 再生完了を監視
+  useEffect(() => {
+    if (state.currentAudio && state.currentAudio.duration && state.currentTime >= state.currentAudio.duration - 5) {
+      // 残り5秒以下で完了とみなす
+      recordListenHistory(state.currentAudio, state.currentTime, state.currentAudio.duration, true);
+    }
+  }, [state.currentTime, state.currentAudio]);
 
   const playAudio = async (audioContent: AudioContent) => {
     try {
@@ -107,6 +180,14 @@ export const AudioPlayerProvider: React.FC<AudioPlayerProviderProps> = ({ childr
       
       dispatch({ type: 'SET_CURRENT_AUDIO', payload: audioContent });
       dispatch({ type: 'SET_PLAYING', payload: true });
+
+      // 履歴から開始時間が指定されている場合はシークする
+      if (audioContent.startTime && audioContent.startTime > 0) {
+        await seekTo(audioContent.startTime);
+      }
+
+      // 再生開始時に履歴を記録
+      recordListenHistory(audioContent, audioContent.startTime || 0, audioContent.duration);
     } catch (error) {
       console.error('再生開始エラー:', error);
       dispatch({ type: 'SET_ERROR', payload: '音声の再生開始に失敗しました' });

--- a/src/contexts/AudioPlayerContext.tsx
+++ b/src/contexts/AudioPlayerContext.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { createContext, useContext, useReducer, ReactNode, useRef, useEffect } from 'react';
+import React, { createContext, useContext, useReducer, ReactNode, useRef, useEffect, useCallback } from 'react';
 import { playbackApi, listenHistoryApi } from '../lib/api';
 
 interface AudioContent {
@@ -116,7 +116,7 @@ export const AudioPlayerProvider: React.FC<AudioPlayerProviderProps> = ({ childr
   };
 
   // 視聴履歴の記録を開始する関数
-  const startHistoryRecording = (audioContent: AudioContent) => {
+  const startHistoryRecording = useCallback((audioContent: AudioContent) => {
     if (historyRecordInterval.current) {
       clearInterval(historyRecordInterval.current);
     }
@@ -131,7 +131,7 @@ export const AudioPlayerProvider: React.FC<AudioPlayerProviderProps> = ({ childr
         }
       }
     }, 5000); // 5秒間隔で記録
-  };
+  }, [state.currentTime, state.isPlaying, state.currentAudio]);
 
   // 視聴履歴の記録を停止する関数
   const stopHistoryRecording = () => {
@@ -161,7 +161,7 @@ export const AudioPlayerProvider: React.FC<AudioPlayerProviderProps> = ({ childr
         }
       }
     }
-  }, [state.isPlaying, state.currentAudio]);
+  }, [state.isPlaying, state.currentAudio, startHistoryRecording, state.currentTime]);
 
   // 再生完了を監視
   useEffect(() => {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -121,8 +121,27 @@ export const audioContentApi = {
     category?: string;
     search?: string;
     isLiked?: boolean;
+    minDuration?: number;
+    maxDuration?: number;
+    sortBy?: string;
   }) => {
     const response = await api.get('/audio-contents', { params });
+    return response.data;
+  },
+
+  search: async (query: string, params?: {
+    page?: number;
+    limit?: number;
+    category?: string;
+    minDuration?: number;
+    maxDuration?: number;
+    sortBy?: string;
+  }) => {
+    const searchParams = {
+      search: query,
+      ...params
+    };
+    const response = await api.get('/audio-contents', { params: searchParams });
     return response.data;
   },
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -282,6 +282,36 @@ export const playbackApi = {
   }
 };
 
+export const listenHistoryApi = {
+  getAll: async (params?: {
+    page?: number;
+    limit?: number;
+  }) => {
+    const response = await api.get('/listen-history', { params });
+    return response.data;
+  },
+
+  getByContentId: async (audioContentId: number) => {
+    const response = await api.get(`/listen-history/content/${audioContentId}`);
+    return response.data;
+  },
+
+  record: async (historyData: {
+    audioContentId: number;
+    currentTime?: number;
+    duration?: number;
+    completed?: boolean;
+  }) => {
+    const response = await api.post('/listen-history', historyData);
+    return response.data;
+  },
+
+  delete: async (id: number) => {
+    const response = await api.delete(`/listen-history/${id}`);
+    return response.data;
+  }
+};
+
 export const isAuthenticated = (): boolean => {
   if (typeof window === 'undefined') return false;
   return !!localStorage.getItem('token');

--- a/src/types/listenHistory.ts
+++ b/src/types/listenHistory.ts
@@ -1,0 +1,41 @@
+export interface ListenHistory {
+  id: number;
+  currentTime: number;
+  duration?: number;
+  completed: boolean;
+  createdAt: string;
+  updatedAt: string;
+  userId: number;
+  audioContentId: number;
+  audioContent: {
+    id: number;
+    title: string;
+    description: string;
+    duration?: number;
+    audioUrl: string;
+    thumbnailUrl?: string;
+    author: {
+      id: number;
+      name?: string;
+    };
+    category: {
+      id: number;
+      name: string;
+    };
+  };
+}
+
+export interface ListenHistoryResponse {
+  data: ListenHistory[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+export interface CreateListenHistoryDto {
+  audioContentId: number;
+  currentTime?: number;
+  duration?: number;
+  completed?: boolean;
+}


### PR DESCRIPTION
## Summary
• 視聴履歴ページ(/dashboard/history)を新規作成し、ユーザーの視聴記録を表示
• AudioPlayerContextに視聴履歴記録機能を統合し、自動的に再生状況を記録
• 続きから再生機能により、前回停止した位置から再開可能
• サイドバーに視聴履歴リンクを追加してナビゲーションを改善

## 主な機能
- 視聴履歴一覧表示（ページネーション対応）
- 視聴進捗のプログレスバー表示
- 続きから再生機能
- 視聴履歴の削除機能
- 再生時の自動履歴記録（5秒間隔）
- 視聴完了の自動検出

## Test plan
- [ ] 視聴履歴ページの表示テスト
- [ ] 続きから再生機能のテスト
- [ ] 視聴履歴の自動記録テスト
- [ ] 視聴履歴削除機能のテスト
- [ ] プログレスバーの表示テスト
- [ ] ページネーション機能のテスト

🤖 Generated with [Claude Code](https://claude.ai/code)