### PR TITLE
feat: Google OAuth認証の実装

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -50,7 +50,8 @@
       "WebFetch(domain:github.com)",
       "Bash(npx prisma db seed:*)",
       "Bash(npx prisma:*)",
-      "Bash(npm run test:*)"
+      "Bash(npm run test:*)",
+      "Bash(npm test:*)"
     ],
     "deny": []
   },

--- a/src/app/auth/callback/[token]/page.tsx
+++ b/src/app/auth/callback/[token]/page.tsx
@@ -1,22 +1,18 @@
 'use client';
 
-import { useEffect } from 'react';
-import { useRouter, useParams } from 'next/navigation';
+import { useEffect, Suspense } from 'react';
+import { useParams } from 'next/navigation';
 import { setAuthToken } from '@/src/lib/api';
 
-export default function AuthCallbackTokenPage() {
-  const router = useRouter();
+function AuthCallbackTokenContent() {
   const params = useParams();
 
   useEffect(() => {
     const token = params.token as string;
 
     if (token) {
-      // トークンを保存
       localStorage.setItem('token', token);
       setAuthToken(token);
-      
-      // 完全にページをリロードしてダッシュボードへ移動
       window.location.href = '/dashboard';
     } else {
       window.location.href = '/login?error=no_token';
@@ -30,5 +26,18 @@ export default function AuthCallbackTokenPage() {
         <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-gray-900 dark:border-white mx-auto"></div>
       </div>
     </div>
+  );
+}
+
+export default function AuthCallbackTokenPage() {
+  return (
+    <Suspense fallback={<div className="min-h-screen flex items-center justify-center">
+      <div className="text-center">
+        <h1 className="text-2xl font-bold mb-4">認証中...</h1>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-gray-900 dark:border-white mx-auto"></div>
+      </div>
+    </div>}>
+      <AuthCallbackTokenContent />
+    </Suspense>
   );
 }

--- a/src/app/auth/callback/[token]/page.tsx
+++ b/src/app/auth/callback/[token]/page.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter, useParams } from 'next/navigation';
+import { setAuthToken } from '@/src/lib/api';
+
+export default function AuthCallbackTokenPage() {
+  const router = useRouter();
+  const params = useParams();
+
+  useEffect(() => {
+    const token = params.token as string;
+
+    if (token) {
+      // トークンを保存
+      localStorage.setItem('token', token);
+      setAuthToken(token);
+      
+      // 完全にページをリロードしてダッシュボードへ移動
+      window.location.href = '/dashboard';
+    } else {
+      window.location.href = '/login?error=no_token';
+    }
+  }, [params.token]);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <div className="text-center">
+        <h1 className="text-2xl font-bold mb-4">認証中...</h1>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-gray-900 dark:border-white mx-auto"></div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { setAuthToken } from '@/src/lib/api';
+
+export default function AuthCallbackPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const token = searchParams.get('token');
+    const error = searchParams.get('error');
+
+    if (token) {
+      // トークンを保存
+      localStorage.setItem('token', token);
+      setAuthToken(token);
+      
+      // 完全にページをリロードしてダッシュボードへ移動
+      window.location.href = '/dashboard';
+    } else if (error) {
+      window.location.href = '/login?error=' + error;
+    } else {
+      window.location.href = '/login?error=no_token';
+    }
+  }, [searchParams]);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <div className="text-center">
+        <h1 className="text-2xl font-bold mb-4">認証中...</h1>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-gray-900 dark:border-white mx-auto"></div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -1,11 +1,10 @@
 'use client';
 
-import { useEffect } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useEffect, Suspense } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { setAuthToken } from '@/src/lib/api';
 
-export default function AuthCallbackPage() {
-  const router = useRouter();
+function AuthCallbackContent() {
   const searchParams = useSearchParams();
 
   useEffect(() => {
@@ -13,11 +12,8 @@ export default function AuthCallbackPage() {
     const error = searchParams.get('error');
 
     if (token) {
-      // トークンを保存
       localStorage.setItem('token', token);
       setAuthToken(token);
-      
-      // 完全にページをリロードしてダッシュボードへ移動
       window.location.href = '/dashboard';
     } else if (error) {
       window.location.href = '/login?error=' + error;
@@ -33,5 +29,18 @@ export default function AuthCallbackPage() {
         <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-gray-900 dark:border-white mx-auto"></div>
       </div>
     </div>
+  );
+}
+
+export default function AuthCallbackPage() {
+  return (
+    <Suspense fallback={<div className="min-h-screen flex items-center justify-center">
+      <div className="text-center">
+        <h1 className="text-2xl font-bold mb-4">認証中...</h1>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-gray-900 dark:border-white mx-auto"></div>
+      </div>
+    </div>}>
+      <AuthCallbackContent />
+    </Suspense>
   );
 }

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -84,6 +84,38 @@ export default function LoginForm() {
               {isSubmitting ? "ログイン中..." : "ログイン"}
             </motion.button>
           </AnimatedElement>
+
+          <AnimatedElement direction="left" delay={0.4}>
+            <div className="relative">
+              <div className="absolute inset-0 flex items-center">
+                <div className="w-full border-t border-gray-700"></div>
+              </div>
+              <div className="relative flex justify-center text-sm">
+                <span className="px-2 bg-black text-gray-400">または</span>
+              </div>
+            </div>
+          </AnimatedElement>
+
+          <AnimatedElement direction="left" delay={0.5}>
+            <motion.button
+              type="button"
+              onClick={() => {
+                window.location.href = `${process.env.NEXT_PUBLIC_API_URL}/auth/google`;
+              }}
+              disabled={isSubmitting}
+              className="w-full py-3 px-4 bg-white hover:bg-gray-100 text-gray-900 font-medium rounded-lg transition duration-200 disabled:opacity-70 flex items-center justify-center gap-3"
+              whileHover={{ scale: 1.02 }}
+              whileTap={{ scale: 0.98 }}
+            >
+              <svg className="w-5 h-5" viewBox="0 0 24 24">
+                <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
+                <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
+                <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
+                <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
+              </svg>
+              Googleでログイン
+            </motion.button>
+          </AnimatedElement>
         </div>
       </form>
     </div>

--- a/src/components/RegisterForm.tsx
+++ b/src/components/RegisterForm.tsx
@@ -128,6 +128,38 @@ export default function RegisterForm() {
             {isSubmitting ? "登録中..." : "アカウント作成"}
           </motion.button>
         </AnimatedElement>
+
+        <AnimatedElement direction="left" delay={0.6}>
+          <div className="relative">
+            <div className="absolute inset-0 flex items-center">
+              <div className="w-full border-t border-gray-700"></div>
+            </div>
+            <div className="relative flex justify-center text-sm">
+              <span className="px-2 bg-black text-gray-400">または</span>
+            </div>
+          </div>
+        </AnimatedElement>
+
+        <AnimatedElement direction="left" delay={0.7}>
+          <motion.button
+            type="button"
+            onClick={() => {
+              window.location.href = `${process.env.NEXT_PUBLIC_API_URL}/auth/google`;
+            }}
+            disabled={isSubmitting}
+            className="w-full py-3 px-4 bg-white hover:bg-gray-100 text-gray-900 font-medium rounded-lg transition duration-200 disabled:opacity-70 flex items-center justify-center gap-3"
+            whileHover={{ scale: 1.02 }}
+            whileTap={{ scale: 0.98 }}
+          >
+            <svg className="w-5 h-5" viewBox="0 0 24 24">
+              <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
+              <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
+              <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
+              <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
+            </svg>
+            Googleで新規登録
+          </motion.button>
+        </AnimatedElement>
       </form>
     </div>
   );

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -16,7 +16,7 @@ interface AuthContextType {
   isAuthenticated: boolean;
   user: User | null;
   loading: boolean;
-  login: (email: string, password: string) => Promise<void>;
+  login: (emailOrToken: string, password?: string) => Promise<void>;
   register: (email: string, password: string, name?: string) => Promise<void>;
   logout: () => void;
   error: string | null;
@@ -81,20 +81,27 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     }
   };
 
-  const login = async (email: string, password: string) => {
+  const login = async (emailOrToken: string, password?: string) => {
     setError(null);
     try {
-      const data = await authApi.login(email, password);
-
-      if (data.access_token) {
-        localStorage.setItem('token', data.access_token);
-        localStorage.setItem('userEmail', email);
-        setAuthToken(data.access_token);
-        await loadUserProfile();
-        router.push('/dashboard');
+      let token: string;
+      
+      if (password) {
+        const data = await authApi.login(emailOrToken, password);
+        if (data.access_token) {
+          token = data.access_token;
+          localStorage.setItem('userEmail', emailOrToken);
+        } else {
+          throw new Error('トークンが取得できませんでした');
+        }
       } else {
-        throw new Error('トークンが取得できませんでした');
+        token = emailOrToken;
       }
+
+      localStorage.setItem('token', token);
+      setAuthToken(token);
+      await loadUserProfile();
+      router.push('/dashboard');
     } catch (error: unknown) {
       if (error instanceof Error) {
         setError(error.message);


### PR DESCRIPTION
## 概要
Google OAuth 2.0による認証機能を実装しました。

## 変更内容
- 🔐 Google OAuth 2.0認証フローの実装
- 📄 認証コールバックページの追加（/auth/callback）
- 🔧 AuthContextにトークンベースのログイン対応を追加
- 🎨 ログイン/登録フォームにGoogleログインボタンを追加

## テスト項目
- [ ] Googleログインボタンをクリックすると、Googleの認証画面に遷移する
- [ ] 認証成功後、ダッシュボードにリダイレクトされる
- [ ] 認証エラー時、適切なエラーメッセージが表示される
- [ ] ローカルストレージにトークンが保存される

🤖 Generated with [Claude Code](https://claude.ai/code)